### PR TITLE
Use globalThis as global by default

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 /* eslint-env browser */
+/* global globalThis */
 
 module.exports = IdbKvStore
 
@@ -6,7 +7,7 @@ var EventEmitter = require('events').EventEmitter
 var inherits = require('inherits')
 var promisize = require('promisize')
 
-var global = typeof window === 'undefined' ? self : window
+var global = typeof globalThis === 'undefined' ? (typeof window === 'undefined' ? self : window) : globalThis
 var IDB = global.indexedDB || global.mozIndexedDB || global.webkitIndexedDB || global.msIndexedDB
 
 IdbKvStore.INDEXEDDB_SUPPORT = IDB != null


### PR DESCRIPTION
Even though this module isn't going to work in a node environment, it is inconvenient that importing it throws since neither `window` nor `self` is defined.

The solution is to use the new standard global `globalThis` if available, which should be defined in all new environments. If it's not available, fall back to the previous behavior.